### PR TITLE
Dialog: use named attributes for Datalog tuples

### DIFF
--- a/.custom-words.txt
+++ b/.custom-words.txt
@@ -23,6 +23,7 @@ DNSLink
 DSL
 DSync
 EDB
+EVAC
 Encryptions
 FPP
 Filecoin


### PR DESCRIPTION
📙 [Preview](https://github.com/fission-codes/spec/tree/dialog-v0.1.0-attributes/dialog/README.md)

The original draft of this used positional arguments to the tuples, but existing Datalog systems + my own experience writing Datalog makes it clear that we want to treat named attributed as a first-class feature to ease maintainability and adoption

This just swaps out the existing code examples to use attributes + changes the relevant copy.