### PR TITLE
Dialog: Use PomoDB codenames for each piece of the system

### DIFF
--- a/.custom-words.txt
+++ b/.custom-words.txt
@@ -52,9 +52,13 @@ OOM
 PSU
 Philipp
 PomoDB
+PomoDB's
 PomoRA
+PomoRA's
 PomoFlow
+PomoFlow's
 PomoLogic
+PomoLogic's
 Prolog
 Qri's
 Ramen

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -1,4 +1,4 @@
-# Dialog Specification v0.1.0 (Draft)
+# PomoDB v0.1.0 (Draft)
 
 ## Editors
 
@@ -12,9 +12,9 @@
 
 ## Specs
 
-* [Dataflow Runtime](./dialog/dataflow.md)
-* [Query Engine](./dialog/query-engine.md)
-* [Relational Algebra](./dialog/relational-algebra.md)
+* [PomoFlow](./pomo_db/pomo_flow.md)
+* [PomoLogic](./pomo_db/pomo_logic.md)
+* [PomoRA](./pomo_db/pomo_ra.md)
 
 ## Appendices
 
@@ -31,7 +31,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Abstract
 
-Dialog is a content-addressable database designed for use in far-edge deployments, such as on IoT or consumer devices. It targets this use case by enabling peers to synchronize heterogenous sets of end-to-end encrypted data in an eventually consistent manner.
+PomoDB is a content-addressable database designed for use in far-edge deployments, such as on IoT or consumer devices. It targets this use case by enabling peers to synchronize heterogenous sets of end-to-end encrypted data in an eventually consistent manner.
 
 # 1. Introduction
 
@@ -41,7 +41,7 @@ While existing databases increasingly treat network partitions as unavoidable di
 
 Such techniques are unsuitable for far-edge and local-first applications, where disorder is the norm, network partitions are ubiquitous and unbounded, and there's an uncompromising need for availability. These environments also often involve dynamic network topologies made up of heterogenous peers, for which common definitions of consistency may not apply.
 
-Dialog addresses these constraints through its query engine, whose semantics guarantee eventual consistency across peers with access to the same sources of data. These guarantees are preserved through changes to a peer's access to data, and mean that Dialog is able to act as a sound foundation for globally distributed data with an indeterminate number of transient peers with varied access patterns.
+PomoDB addresses these constraints through its query engine, whose semantics guarantee eventual consistency across peers with access to the same sources of data. These guarantees are preserved through changes to a peer's access to data, and mean that PomoDB is able to act as a sound foundation for globally distributed data with an indeterminate number of transient peers with varied access patterns.
 
 ## 1.2 Insights
 
@@ -55,20 +55,18 @@ TODO: discuss CALM Theorem and its connection with Datalog
 
 # 2. Design
 
-Dialog can be broken up into two core components: the query engine, and its storage layer.
+PomoDB can be broken up into two core components: the query engine, and its storage layer.
 
 ## 2.1 Query Engine
-Dialog has no specified query language. Instead, an intermediate representation based on the [relational algebra](../dialog/dialog/relational-algebra.md) is defined.
+PomoDB has no specified query language. Instead, an intermediate representation based on the relation algebra, named [PomoRA](./pomo_db/pomo_ra.md), is defined.
 
-An OPTIONAL [Datalog variant](../dialog/dialog/query-engine.md) is described, along with an [algorithm](../dialog/dialog/relational-algebra.md#5-compilation-from-dialog) for translating it to the relational algebra IR.
+An OPTIONAL Datalog variant, named [PomoLogic](./pomo_db/pomo_logic.md), is described, along with an [algorithm](./pomo_db/pomo_ra.md#5-compilation-from-pomo-logic) for translating it to PomoRA.
 
-Implementations MAY define their own user-facing query language, but they are RECOMMENDED to treat the relational algebra IR as a common compilation target for all such languages.
-
-TODO: "relational algebra IR" is wordy. We should just give these layers names. Maybe PomoLogic -> PomoRA -> PomoFlow?
+Implementations MAY define their own user-facing query language, but they are RECOMMENDED to treat PomoRA as a common compilation target for all such languages.
 
 TODO: Talk about compiling SQL to PomoRA too. That should probably be another linked spec, but I should tackle one thing at a time.
 
-This IR is then compiled to a form suitable for being evaluated by an implementation-defined runtime. An OPTIONAL [dataflow runtime](../dialog/dialog/dataflow.md) is described, but implementations MAY implement a simpler runtime, based on semi-naive evaluation.
+This IR is then compiled to a form suitable for being evaluated by an implementation-defined runtime. An OPTIONAL dataflow runtime, named [PomoFlow](./pomo_db/pomo_flow.md), is described, but implementations MAY implement a simpler runtime, such as one based on semi-naive evaluation.
 
 TODO: Should we describe a simple specification for semi-naive evaluation yet, or just link to some resources? We'll definitely want to specify that too, at some point, but I'd prefer specifying one target to start, so we can launch sooner.
 

--- a/dialog/RESEARCH.md
+++ b/dialog/RESEARCH.md
@@ -1,6 +1,6 @@
 # Research
 
-This document contains a short list of relevant research to Dialog. It is not exhaustive.
+This document contains a short list of relevant research to PomoDB. It is not exhaustive.
 
 - [Datalog and Recursive Query Processing](http://blogs.evergreen.edu/sosw/files/2014/04/Green-Vol5-DBS-017.pdf)
 - [DBSP: Automatic Incremental View Maintenance for Rich Query Languages](https://arxiv.org/abs/2203.16684)

--- a/dialog/pomo_db/pomo_flow.md
+++ b/dialog/pomo_db/pomo_flow.md
@@ -1,4 +1,4 @@
-# Dataflow Runtime
+# PomoFlow
 
 ## Authors
 
@@ -11,7 +11,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Abstract
 
-This document provides a recommendation for implementing Dialog's query engine in terms of a dataflow based runtime. This design is especially suited for incrementalizing programs to efficiently compute over deltas to the input EDB.
+This document describes PomoFlow, a dataflow runtime for PomoDB. This design is especially suited for incrementalizing programs to efficiently compute over deltas to the input EDB.
 
 # 1. Introduction
 
@@ -19,7 +19,7 @@ Most Datalog runtimes implement a variant of semi-naive evaluation, where querie
 
 This document describes an alternative runtime, built on dataflow, which represents programs as circuits whose vertices and edges correspond to computations over streams of data. These circuits can be incrementalized to instead operate over deltas, with the results being combined back into a materialized view.
 
-Since the stream computations correspond to the relational algebra, compiling to these circuits from Datalog (and thus Dialog) is simple, and is also described in this document.
+Since the stream computations correspond to the relational algebra, compiling to these circuits from PomoRA is simple, and is also described in this document.
 
 The design is based on ideas from Differential Dataflow, and is heavily inspired by the Database Stream Processor Framework (DBSP). Links to both can be found in the [research appendices](./RESEARCH.md).
 
@@ -115,7 +115,7 @@ Under this example, using product order, `(0, 0) <= (0, 1) <= (1, 1)`, but neith
 
 ## 2.6 Circuit
 
-A circuit is an embedding of a Dialog program into a directed graph whose vertices, called [nodes](#28-node), represent computation against [streams](#27-stream), and whose edges describe those streams.
+A circuit is an embedding of a PomoRA query plan into a directed graph whose vertices, called [nodes](#28-node), represent computation against [streams](#27-stream), and whose edges describe those streams.
 
 Circuits may contain subcircuits, representing recursive subcomputations that evaluate to a fixed point every iteration.
 
@@ -211,7 +211,7 @@ This operator takes an [Indexed ZSet](#22-indexed-zset) as input, and applies an
 
 (TODO: maybe it should use the circuit's current timestamp. I need to do some experimentation with timestamps because I think I can simplify the model slightly)
 
-Implementations MAY support user defined aggregates, but MUST support the aggregate functions described in the [specification for the query language](query-engine.md#aggregation).
+Implementations MAY support user defined aggregates, but MUST support the aggregate functions described in the [specification for the query language](pomo_logic.md#aggregation).
 
 If additional aggregates are supported, they MUST be pure functions, and implementations are RECOMMENDED to enforce this constraint.
 

--- a/dialog/pomo_db/pomo_ra.md
+++ b/dialog/pomo_db/pomo_ra.md
@@ -1,4 +1,4 @@
-# Relational Algebra
+# PomoRA
 
 ## Authors
 
@@ -11,15 +11,15 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Abstract
 
-The relational algebra forms a common compilation target for Datalog programs. This specification outlines the semantics of the algebra, and describes its operations in terms useful for further compilation to a model with support for incrementalization and recursive queries.
+The relational algebra forms a common compilation target for Datalog programs. This specification outlines the semantics of PomoRA, a representation of the relational algebra designed for use as a compilation target for high-level PomoDB query languages. It also describes PomoRA's operations in terms useful for further compilation to a runtime with support for incrementalization and recursive query processing.
 
 # 1. Introduction
 
-Relational algebra is the theory underpinning relational databases, and query languages against them. Like Datalog, it operates over relations as input, and produces relations as output. Unlike Datalog, it is unable to directly express recursive queries, and such programs must be implemented in terms of a more expressive model, such as one built on [dataflow](dataflow.md).
+Relational algebra is the theory underpinning relational databases, and query languages against them. Like Datalog, it operates over relations as input, and produces relations as output. Unlike Datalog, it is unable to directly express recursive queries, and such programs must be implemented in terms of a more powerful runtime, such as [PomoFlow](pomo_flow.md).
 
-In the context of Dialog, the relational algebra serves two purposes:
-1) Providing a small core language for further compilation to a runtime with support for recursive queries
-2) Serving as a common intermediate representation for both queries written using familiar SQL-inspired DSLs, and for those written using [richer, higher-level languages, like Dialog](../dialog/query-engine.md).
+In the context of PomoDB, the relational algebra serves two purposes:
+1) Providing a small core language for further compilation to a runtime with support for recursive query processing
+2) Serving as a common intermediate representation for both queries written using familiar SQL-inspired DSLs, and for those written using richer, higher-level languages, like [PomoLogic](pomo_logic.md).
 
 # 2. Concepts
 
@@ -35,7 +35,7 @@ A n-ary relation contains n-tuples, which can each be written:
 
 Where `a1, a2, ..., an` give the names of each attribute, and `v1, v2, ..., vn` their values.
 
-Each tuple within a relation also has a content identifier (CID), as described in the specification of the [query engine](../dialog/query-engine.md#132-content-addressing). This CID can be accessed through a special control attribute that this document will denote as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
+Each tuple within a relation also has a content identifier (CID), as described in the specification for [PomoLogic](pomo_logic.md#132-content-addressing). This CID can be accessed through a special control attribute that this document will denote as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
 
 # 3. Operations
 
@@ -367,7 +367,9 @@ This operation is equivalent to taking the [difference](#35-difference) of the f
 
 Group by is the mechanism by which aggregation is performed. Group by is performed over a relation with respect to a set of grouping attributes, and an aggregate function. The operation returns the set of tuples computed by first grouping the input relation, and then applying the aggregate function to each group.
 
-Implementations MAY support user defined aggregates, but MUST support the aggregate functions described in the [specification for the query language](query-engine.md#aggregation).
+TODO: Move the specification of aggregates from PomoLogic to here
+
+Implementations MAY support user defined aggregates, but MUST support the aggregate functions described in the specification for [PomoLogic](pomo_logic.md#aggregation).
 
 For example:
 
@@ -421,13 +423,13 @@ select(formula, users) => [
 ]
 ```
 
-# 5. Compilation from Dialog
+# 5. Compilation from PomoLogic
 
 TODO: I realize this is very verbose and that it can be simplified and broken up. I'll worry about that after the first pass through describing things :)
 
-## 5.1 Non-Recursive Dialog
+TODO: I need to move some details from PomoLogic to here, so that PomoRA can reuse ideas like provenance, CIDs, time, and stratification
 
-The translation from non-recursive [Dialog](../dialog/query-engine.md) to a relational algebra query plan is straightforward, and can be performed by first compiling each rule in isolation, and then taking the [union](#34-union) of the query plans for any rules with matching head atoms.
+The translation from [PomoLogic](pomo_logic.md) to a relational algebra query plan is straightforward, and can be performed by first compiling each rule in isolation, and then taking the [union](#34-union) of the query plans for any rules with matching head atoms.
 
 A rule is compiled by constructing a query plan from the terms within the rule's body, with respect to the rule's head. Such query plans are not unique, and implementations MAY define their own approach to query planning, but the semantics of the generated query plan MUST match the query plan generated using the following approach.
 
@@ -484,6 +486,6 @@ Next, from the rule's head, `atom(a0: v0, ..., an: vn)`, collect each attribute,
 
 Now, taking the [union](#34-union) of all rules which share a head relation will give the query plan for that relation.
 
-Lastly, [stratify](../dialog/query-engine.md#133-stratification) each of these relations and partition the query plans by the strata they belong to.
+Lastly, [stratify](pomo_logic.md#133-stratification) each of these relations and partition the query plans by the strata they belong to.
 
 TODO: add diagrams + examples for each of these steps


### PR DESCRIPTION
📙 [Preview](https://github.com/fission-codes/spec/tree/quinn/dialog-naming/dialog/README.md)


These names aren't final, but serve as useful placeholders for each layer of the compilation pipeline, and give concrete places to point when discussing where in the spec the different ideas belong.

I'll be doing some major reorganizing shortly.