### PR TITLE
PomoDB: Move definition of builtin aggregates from PomoLogic -> PomoRA

### DIFF
--- a/dialog/pomo_db/pomo_logic.md
+++ b/dialog/pomo_db/pomo_logic.md
@@ -325,15 +325,9 @@ totalStock(category: Category, total: Total) :-
   Total := sum Quantity : product(category: Category, quantity: Quantity).
 ```
 
-Implementations are RECOMMENDED to support `count`, `sum`, `min`, and `max` as aggregates, but MAY provide additional built-in aggregates or allow user defined aggregate functions.
+Implementations MUST support the aggregate functions defined by [PomoRA](pomo_ra.md#312-group-by), and MAY provide additional non-standard aggregates or allow user defined aggregate functions.
 
-If implemented, these aggregates MUST be defined as follows:
-- `count` MUST return the number of matched tuples
-- `sum` MUST return the sum of the selected argument in the matched tuples
-- `min` MUST return the minimum of the selected argument in the matched tuples
-- `max` MUST return the maximum of the selected argument in the matched tuples
-
-The argument's to an aggregate's atom form a lexical scope under the rule's body, and new bindings introduced in this scope MUST NOT be accessible to other predicates.
+The arguments to an aggregate's atom form a lexical scope under the rule's body, and new bindings introduced in this scope MUST NOT be accessible to other predicates.
 
 For example, the following rule is not range restricted, and thus invalid, because `Category` is unbound in the rule's head:
 

--- a/dialog/pomo_db/pomo_ra.md
+++ b/dialog/pomo_db/pomo_ra.md
@@ -367,9 +367,15 @@ This operation is equivalent to taking the [difference](#35-difference) of the f
 
 Group by is the mechanism by which aggregation is performed. Group by is performed over a relation with respect to a set of grouping attributes, and an aggregate function. The operation returns the set of tuples computed by first grouping the input relation, and then applying the aggregate function to each group.
 
-TODO: Move the specification of aggregates from PomoLogic to here
+Some aggregates, like `sum`, are parameterized over an attribute name which defines which attribute of the matched tuples to aggregate over.
 
-Implementations MAY support user defined aggregates, but MUST support the aggregate functions described in the specification for [PomoLogic](pomo_logic.md#aggregation).
+Implementations MUST support the following aggregates:
+- `count` returns the number of matched tuples
+- `sum(x)` returns the sum of the selected attribute, `x`, in the matched tuples
+- `min(x)` returns the minimum among the selected attribute, `x`, in the matched tuples
+- `max(x)` returns the maximum among the selected attribute, `x`, in the matched tuples
+
+Implementations MAY support user defined aggregates, and such aggregates MUST be deterministic and free of side-effects.
 
 For example:
 


### PR DESCRIPTION
📙 [Preview](https://github.com/fission-codes/spec/tree/quinn/dialog-move-aggregates/dialog/README.md)