### PR TITLE
Dialog: Reorganize and restructure concepts based on their dependencies

### DIFF
--- a/dialog/README.md
+++ b/dialog/README.md
@@ -82,9 +82,9 @@ Where `a1, a2, ..., an` give the names of each attribute, and `v1, v2, ..., vn` 
 
 ### 2.2.1 CID Attribute
 
-Each tuple within a relation also has a content identifier (CID), as described in the specification for [PomoLogic](pomo_db/pomo_logic.md#132-content-addressing).
+Each tuple within a relation also has a [content identifier](#23-content-addressing) (CID).
 
-This CID can be accessed through a special control attribute that this document will denote as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
+This CID can be accessed through a special control attribute denoted as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
 
 ## 2.3 Content Addressing
 

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -98,6 +98,7 @@ These properties are further leveraged in the design and use of byzantine-fault 
 
 TODO: Update CRDT link once that info is described somewhere
 
+
 ## 2.4 Provenance Tracking
 
 TODO: https://discord.com/channels/478735028319158273/1033502043656171561/1035339517021921280
@@ -110,6 +111,24 @@ Implementations MAY define their own user-facing query language, but they are RE
 
 An OPTIONAL Datalog variant, named [PomoLogic](pomo_db/pomo_logic.md), is also described, along with an OPTIONAL runtime for PomoRA, named [PomoFlow](pomo_db/pomo_flow.md).
 
-## 2.6 Storage
+## 2.6 Sources
+
+Sources introduce tuples from the outside world to a running PomoDB query, and can be queried as if they were [relations](#22-relation).
+
+Implementations MAY define their own sources, but sources SHOULD be non-blocking, and are RECOMMENDED to perform any blocking or IO-intensive operations asynchronously.
+
+Sources MAY emit deltas of tuples, if a runtime able to take advantage of incremental computation is being used, like [PomoFlow](pomo_db/pomo_flow.md).
+
+Implementations MAY also support user defined sources, such as to facilitate the integration of PomoDB into external systems for persistence or communication.
+
+## 2.7 Sinks
+
+Sinks handle derived tuples for further processing by the outside world, and can be inserted into as if they were [relations](#22-relation).
+
+Implementations MAY define their own sinks, but sinks SHOULD be non-blocking, and are RECOMMENDED to perform any blocking or IO-intensive operations asynchronously.
+
+Implementations MAY also support user defined sinks, such as to facilitate the integration of PomoDB into external systems for persistence or communication.
+
+## 2.8 Storage
 
 TODO: Introduce + link Brooke's upcoming work on persistence + encryption

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -80,7 +80,11 @@ A n-ary relation contains n-tuples, which can each be written:
 
 Where `a1, a2, ..., an` give the names of each attribute, and `v1, v2, ..., vn` their values.
 
-Each tuple within a relation also has a content identifier (CID), as described in the specification for [PomoLogic](pomo_db/pomo_logic.md#132-content-addressing). This CID can be accessed through a special control attribute that this document will denote as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
+### 2.2.1 CID Attribute
+
+Each tuple within a relation also has a content identifier (CID), as described in the specification for [PomoLogic](pomo_db/pomo_logic.md#132-content-addressing).
+
+This CID can be accessed through a special control attribute that this document will denote as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
 
 ## 2.3 Content Addressing
 
@@ -100,17 +104,11 @@ TODO: https://discord.com/channels/478735028319158273/1033502043656171561/103533
 
 ## 2.5 Query Engine
 
-PomoDB has no specified query language. Instead, an intermediate representation based on the relation algebra, named [PomoRA](pomo_db/pomo_ra.md), is defined.
-
-An OPTIONAL Datalog variant, named [PomoLogic](pomo_db/pomo_logic.md), is described, along with an [algorithm](pomo_db/pomo_ra.md#4-compilation-from-pomo-logic) for translating it to PomoRA.
+PomoDB has no specified query language. Instead, an intermediate representation based on the relational algebra, named [PomoRA](pomo_db/pomo_ra.md), is defined.
 
 Implementations MAY define their own user-facing query language, but they are RECOMMENDED to treat PomoRA as a common compilation target for all such languages.
 
-TODO: Talk about compiling SQL to PomoRA too. That should probably be another linked spec, but I should tackle one thing at a time.
-
-This IR is then compiled to a form suitable for being evaluated by an implementation-defined runtime. An OPTIONAL dataflow runtime, named [PomoFlow](pomo_db/pomo_flow.md), is described, but implementations MAY implement a simpler runtime, such as one based on semi-naive evaluation.
-
-TODO: Should we describe a simple specification for semi-naive evaluation yet, or just link to some resources? We'll definitely want to specify that too, at some point, but I'd prefer specifying one target to start, so we can launch sooner.
+An OPTIONAL Datalog variant, named [PomoLogic](pomo_db/pomo_logic.md), is also described, along with an OPTIONAL runtime for PomoRA, named [PomoFlow](pomo_db/pomo_flow.md).
 
 ## 2.6 Storage
 

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -82,11 +82,23 @@ Where `a1, a2, ..., an` give the names of each attribute, and `v1, v2, ..., vn` 
 
 ### 2.2.1 CID Attribute
 
-Each tuple within a relation also has a [content identifier](#23-content-addressing) (CID).
+Each tuple within a relation also has a [content identifier](#24-content-addressing) (CID).
 
 This CID can be accessed through a special control attribute denoted as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
 
-## 2.3 Content Addressing
+## 2.3 Time
+
+PomoDB is a temporal database which internally models the progression of time as data changes, with each batch of data relating to a timestamp, called an epoch.
+
+While epochs MUST be represented as an unsigned integer, runtimes MAY refine this representation in order to capture additional metadata about the progression of time.
+
+All such representations MUST form a partial order, such that subsequent epochs are represented using subsequent timestamps. For example, runtimes MAY represent timestamps using a pair that tracks the iteration count of looping queries in the second component, while comparing these pairs using product order.
+
+The database state is modeled as a function of time and the program under evaluation, and all tuples are associated with the timestamp at which they were computed.
+
+PomoDB timestamps form a logical clock and hold no meaning to any other instances of PomoDB.
+
+## 2.4 Content Addressing
 
 As PomoDB is intended for use in distributed and decentralized deployments, it is important ensure the use of collision resistant identifiers when referring to tuples. For this purpose, a content addressing scheme is leveraged, and tuples are associated with a content ID (CID) computed from their structure. The details behind this computation are available in [serialization](pomo_db/serialization.md).
 
@@ -98,11 +110,11 @@ These properties are further leveraged in the design and use of byzantine-fault 
 
 TODO: Update CRDT link once that info is described somewhere
 
-## 2.4 Provenance Tracking
+## 2.5 Provenance Tracking
 
 TODO: https://discord.com/channels/478735028319158273/1033502043656171561/1035339517021921280
 
-## 2.5 Query Engine
+## 2.6 Query Engine
 
 PomoDB has no specified query language. Instead, an intermediate representation based on the relational algebra, named [PomoRA](pomo_db/pomo_ra.md), is defined.
 
@@ -110,19 +122,19 @@ Implementations MAY define their own user-facing query language, but they are RE
 
 An OPTIONAL Datalog variant, named [PomoLogic](pomo_db/pomo_logic.md), is also described, along with an OPTIONAL runtime for PomoRA, named [PomoFlow](pomo_db/pomo_flow.md).
 
-## 2.6 Query Evaluation
+## 2.7 Evaluation
 
-In every runtime, evaluation of PomoDB queries proceeds in timesteps, called epochs, which each compute a least fixed point over a batch of changes to the database.
+Evaluation of PomoDB queries proceeds in timesteps, called epochs, which each compute a least fixed point over a batch of changes to the database.
 
 The details behind this computation are runtime specific, however all runtimes MUST provide the following additional guarantees.
 
-Each epoch is denoted by the timestamp succeeding the last, and begins by scheduling the program's [sources](#27-sources) for evaluation. These sources MAY run in any order, however any operations over their resulting contents MUST be deferred until their completion.
+Each epoch is denoted by the timestamp succeeding the last, and begins by scheduling the program's [sources](#28-sources) for evaluation. These sources MAY run in any order, however any operations over their resulting contents MUST be deferred until their completion.
 
-Upon computing a relation's fixed point, any [sinks](#28-sinks) over that relation SHOULD be scheduled to run over the relation's contents, and evaluation of those sinks MUST be completed before evaluating the next epoch.
+Upon computing a relation's fixed point, any [sinks](#29-sinks) over that relation SHOULD be scheduled to run over the relation's contents, and evaluation of those sinks MUST be completed before evaluating the next epoch.
 
 PomoDB queries MAY be implemented over incremental computations, in which case each epoch is RECOMMENDED to operate over deltas of the database, wherever possible. [PomoFlow](pomo_flow.md) is an OPTIONAL runtime with such capabilities.
 
-## 2.7 Sources
+## 2.8 Sources
 
 Sources act as ingress points for a PomoDB query, and introduce tuples from the outside world, such as by loading them from a local persistence layer, or by querying them from a remote data source such as IPFS.
 
@@ -134,7 +146,7 @@ Sources MAY emit deltas of tuples, if a runtime able to take advantage of increm
 
 Implementations MAY also support user defined sources, such as to facilitate the integration of PomoDB into external systems for persistence or communication.
 
-## 2.8 Sinks
+## 2.9 Sinks
 
 Sinks act as egress points for a PomoDB query, and emit tuples to the outside world for further processing or storage.
 
@@ -144,6 +156,6 @@ Implementations MAY define their own sinks, but sinks SHOULD be non-blocking, an
 
 Implementations MAY also support user defined sinks, such as to facilitate the integration of PomoDB into external systems for persistence or communication.
 
-## 2.9 Storage
+## 2.10 Storage
 
 TODO: Introduce + link Brooke's upcoming work on persistence + encryption

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -98,7 +98,6 @@ These properties are further leveraged in the design and use of byzantine-fault 
 
 TODO: Update CRDT link once that info is described somewhere
 
-
 ## 2.4 Provenance Tracking
 
 TODO: https://discord.com/channels/478735028319158273/1033502043656171561/1035339517021921280
@@ -111,9 +110,23 @@ Implementations MAY define their own user-facing query language, but they are RE
 
 An OPTIONAL Datalog variant, named [PomoLogic](pomo_db/pomo_logic.md), is also described, along with an OPTIONAL runtime for PomoRA, named [PomoFlow](pomo_db/pomo_flow.md).
 
-## 2.6 Sources
+## 2.6 Query Evaluation
 
-Sources introduce tuples from the outside world to a running PomoDB query, and can be queried as if they were [relations](#22-relation).
+In every runtime, evaluation of PomoDB queries proceeds in timesteps, called epochs, which each compute a least fixed point over a batch of changes to the database.
+
+The details behind this computation are runtime specific, however all runtimes MUST provide the following additional guarantees.
+
+Each epoch is denoted by the timestamp succeeding the last, and begins by scheduling the program's [sources](#27-sources) for evaluation. These sources MAY run in any order, however any operations over their resulting contents MUST be deferred until their completion.
+
+Upon computing a relation's fixed point, any [sinks](#28-sinks) over that relation SHOULD be scheduled to run over the relation's contents, and evaluation of those sinks MUST be completed before evaluating the next epoch.
+
+PomoDB queries MAY be implemented over incremental computations, in which case each epoch is RECOMMENDED to operate over deltas of the database, wherever possible. [PomoFlow](pomo_flow.md) is an OPTIONAL runtime with such capabilities.
+
+## 2.7 Sources
+
+Sources act as ingress points for a PomoDB query, and introduce tuples from the outside world, such as by loading them from a local persistence layer, or by querying them from a remote data source such as IPFS.
+
+Sources can be queried as if they were [relations](#22-relation).
 
 Implementations MAY define their own sources, but sources SHOULD be non-blocking, and are RECOMMENDED to perform any blocking or IO-intensive operations asynchronously.
 
@@ -121,14 +134,16 @@ Sources MAY emit deltas of tuples, if a runtime able to take advantage of increm
 
 Implementations MAY also support user defined sources, such as to facilitate the integration of PomoDB into external systems for persistence or communication.
 
-## 2.7 Sinks
+## 2.8 Sinks
 
-Sinks handle derived tuples for further processing by the outside world, and can be inserted into as if they were [relations](#22-relation).
+Sinks act as egress points for a PomoDB query, and emit tuples to the outside world for further processing or storage.
+
+Sinks can be inserted into as if they were [relations](#22-relation).
 
 Implementations MAY define their own sinks, but sinks SHOULD be non-blocking, and are RECOMMENDED to perform any blocking or IO-intensive operations asynchronously.
 
 Implementations MAY also support user defined sinks, such as to facilitate the integration of PomoDB into external systems for persistence or communication.
 
-## 2.8 Storage
+## 2.9 Storage
 
 TODO: Introduce + link Brooke's upcoming work on persistence + encryption

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -112,7 +112,7 @@ TODO: Update CRDT link once that info is described somewhere
 
 ## 2.5 Provenance Tracking
 
-TODO: https://discord.com/channels/478735028319158273/1033502043656171561/1035339517021921280
+TODO: [See notes](https://discord.com/channels/478735028319158273/1033502043656171561/1035339517021921280)
 
 ## 2.6 Query Engine
 

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -55,9 +55,21 @@ TODO: discuss CALM Theorem and its connection with Datalog
 
 # 2. Design
 
-PomoDB can be broken up into two core components: the query engine, and its storage layer.
+## 2.1 Types
 
-## 2.1 Query Engine
+PomoDB is designed to be run within WebAssembly, and so its types and their encodings are informed by the format. See the [WebAssembly specification](https://webassembly.github.io/spec/core/appendix/index-types.html) for more information.
+
+Note, however, that only some types are supported as PomoDB primitives. These are:
+
+- [Numbers](https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype)
+- [Opaque Reference Types](https://webassembly.github.io/spec/core/syntax/types.html#reference-types)
+
+As WebAssembly does not define common types like booleans or strings, these are handled using opaque reference types, and more information is available in the [serialization](./serialization.md) specification.
+
+TODO: Update the above reference once that data exists
+
+## 2.2 Query Engine
+
 PomoDB has no specified query language. Instead, an intermediate representation based on the relation algebra, named [PomoRA](./pomo_db/pomo_ra.md), is defined.
 
 An OPTIONAL Datalog variant, named [PomoLogic](./pomo_db/pomo_logic.md), is described, along with an [algorithm](./pomo_db/pomo_ra.md#5-compilation-from-pomo-logic) for translating it to PomoRA.
@@ -70,6 +82,6 @@ This IR is then compiled to a form suitable for being evaluated by an implementa
 
 TODO: Should we describe a simple specification for semi-naive evaluation yet, or just link to some resources? We'll definitely want to specify that too, at some point, but I'd prefer specifying one target to start, so we can launch sooner.
 
-## 2.2 Storage
+## 2.3 Storage
 
 TODO: Introduce + link Brooke's upcoming work on persistence + encryption

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -12,13 +12,13 @@
 
 ## Specs
 
-* [PomoFlow](./pomo_db/pomo_flow.md)
-* [PomoLogic](./pomo_db/pomo_logic.md)
-* [PomoRA](./pomo_db/pomo_ra.md)
+* [PomoFlow](pomo_db/pomo_flow.md)
+* [PomoLogic](pomo_db/pomo_logic.md)
+* [PomoRA](pomo_db/pomo_ra.md)
 
 ## Appendices
 
-* [Research](./RESEARCH.md)
+* [Research](RESEARCH.md)
 
 ## Links
 
@@ -64,24 +64,54 @@ Note, however, that only some types are supported as PomoDB primitives. These ar
 - [Numbers](https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype)
 - [Opaque Reference Types](https://webassembly.github.io/spec/core/syntax/types.html#reference-types)
 
-As WebAssembly does not define common types like booleans or strings, these are handled using opaque reference types, and more information is available in the [serialization](./serialization.md) specification.
+As WebAssembly does not define common types like booleans or strings, these are handled using opaque reference types, and more information is available in the [serialization](pomo_db/serialization.md) specification.
 
 TODO: Update the above reference once that data exists
 
-## 2.2 Query Engine
+## 2.2 Relation
 
-PomoDB has no specified query language. Instead, an intermediate representation based on the relation algebra, named [PomoRA](./pomo_db/pomo_ra.md), is defined.
+A relation is a set of tuples, where each component of the tuple is called an attribute, and can be referenced by an attribute name.
 
-An OPTIONAL Datalog variant, named [PomoLogic](./pomo_db/pomo_logic.md), is described, along with an [algorithm](./pomo_db/pomo_ra.md#5-compilation-from-pomo-logic) for translating it to PomoRA.
+A n-ary relation contains n-tuples, which can each be written:
+
+```
+(a1: v1, a2: v2, ..., an: vn)
+```
+
+Where `a1, a2, ..., an` give the names of each attribute, and `v1, v2, ..., vn` their values.
+
+Each tuple within a relation also has a content identifier (CID), as described in the specification for [PomoLogic](pomo_db/pomo_logic.md#132-content-addressing). This CID can be accessed through a special control attribute that this document will denote as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
+
+## 2.3 Content Addressing
+
+As PomoDB is intended for use in distributed and decentralized deployments, it is important ensure the use of collision resistant identifiers when referring to tuples. For this purpose, a content addressing scheme is leveraged, and tuples are associated with a content ID (CID) computed from their structure. The details behind this computation are available in [serialization](pomo_db/serialization.md).
+
+The choice of CIDs here, rather than more common choices, like auto incrementing IDs or UUIDs, reflects PomoDB's goals in targeting distributed and decentralized environments, where coordination around the allocation of IDs can't be guaranteed, and where resilience against malicious and byzantine actors is required.
+
+Since content addressing schemes are backed by cryptographically secure hash functions, their use here prevents forgery of IDs by attackers, and guarantees that CID-based dependencies between tuples will be acyclic.
+
+These properties are further leveraged in the design and use of byzantine-fault tolerant CRDTs, as described in [CRDTs](pomo_db/CRDTs.md).
+
+TODO: Update CRDT link once that info is described somewhere
+
+## 2.4 Provenance Tracking
+
+TODO: https://discord.com/channels/478735028319158273/1033502043656171561/1035339517021921280
+
+## 2.5 Query Engine
+
+PomoDB has no specified query language. Instead, an intermediate representation based on the relation algebra, named [PomoRA](pomo_db/pomo_ra.md), is defined.
+
+An OPTIONAL Datalog variant, named [PomoLogic](pomo_db/pomo_logic.md), is described, along with an [algorithm](pomo_db/pomo_ra.md#4-compilation-from-pomo-logic) for translating it to PomoRA.
 
 Implementations MAY define their own user-facing query language, but they are RECOMMENDED to treat PomoRA as a common compilation target for all such languages.
 
 TODO: Talk about compiling SQL to PomoRA too. That should probably be another linked spec, but I should tackle one thing at a time.
 
-This IR is then compiled to a form suitable for being evaluated by an implementation-defined runtime. An OPTIONAL dataflow runtime, named [PomoFlow](./pomo_db/pomo_flow.md), is described, but implementations MAY implement a simpler runtime, such as one based on semi-naive evaluation.
+This IR is then compiled to a form suitable for being evaluated by an implementation-defined runtime. An OPTIONAL dataflow runtime, named [PomoFlow](pomo_db/pomo_flow.md), is described, but implementations MAY implement a simpler runtime, such as one based on semi-naive evaluation.
 
 TODO: Should we describe a simple specification for semi-naive evaluation yet, or just link to some resources? We'll definitely want to specify that too, at some point, but I'd prefer specifying one target to start, so we can launch sooner.
 
-## 2.3 Storage
+## 2.6 Storage
 
 TODO: Introduce + link Brooke's upcoming work on persistence + encryption

--- a/dialog/RESEARCH.md
+++ b/dialog/RESEARCH.md
@@ -5,3 +5,4 @@ This document contains a short list of relevant research to PomoDB. It is not ex
 - [Datalog and Recursive Query Processing](http://blogs.evergreen.edu/sosw/files/2014/04/Green-Vol5-DBS-017.pdf)
 - [DBSP: Automatic Incremental View Maintenance for Rich Query Languages](https://arxiv.org/abs/2203.16684)
 - [Differential Dataflow](https://www.cidrdb.org/cidr2013/Papers/CIDR13_Paper111.pdf)
+- [Queries are easier than you thought (probably)](https://dl.acm.org/doi/pdf/10.1145/137097.137105)

--- a/dialog/pomo_db/pomo_flow.md
+++ b/dialog/pomo_db/pomo_flow.md
@@ -25,7 +25,7 @@ The design is based on ideas from Differential Dataflow, and is heavily inspired
 
 ## 2.1 ZSet
 
-A set of elements, each associated with a [weight](#24-weight) and [timestamp](#25-timestamp).
+A set of elements, each associated with a [weight](#24-weight) and [timestamp](#25-time).
 
 ZSets can be written as lists of triples:
 
@@ -43,7 +43,7 @@ Some operations return ZSets without timestamp information, and implementations 
 
 ## 2.2 Indexed ZSet
 
-A set of key-value pairs, each associated with a [weight](#24-weight) and [timestamp](#25-timestamp).
+A set of key-value pairs, each associated with a [weight](#24-weight) and [timestamp](#25-time).
 
 Indexed ZSets can be written as lists of triples:
 
@@ -81,13 +81,13 @@ Implementations MUST support efficient sequential access of traces, first by key
 
 An integer associated with each element of a ZSet. Positive weights indicate the number of derivations of that element within the ZSet, and negative weights indicate the number of deletions of that element.
 
-## 2.5 Timestamp
+## 2.5 Time
 
-Every iteration of a [circuit](#26-circuit) is associated with a timestamp, and computed values are associated with the timestamp from which they were derived.
+PomoFlow represents [timestamps](../README.md#23-time) for the root circuit using a counter which denotes the current epoch.
 
-Timestamps MUST be represented using a partial order, such that subsequent iterations of the same [circuit](#26-circuit) have subsequent timestamps, and the timestamps of recursive subcircuits are given by refinements of the parent circuit's timestamp that allow iterations of that subcircuit to be distinguished and filtered according to that timestamp, called its epoch.
+Every recursive subcircuit refines its parent's timestamp using a pair which further associates that timestamp with the iteration count through the subcircuit. These pairs are ordered using product order.
 
-Implementations MAY represent timestamps for the root circuit as an integer, and timestamps for subcircuits as a pair constructed from their parent's timestamp, and an integer, and ordered using product order.
+Implementations MUST represent both epochs and iteration counts as an unsigned integer.
 
 For example, a root circuit may progress through the following timestamps:
 
@@ -385,7 +385,7 @@ Note that because operator computes the delta of [Distinct](#293-distinct-operat
 
 Distinct is not a linear operation, and requires access to the entire history of updates, however there's a few observations that can reduce the search space of timestamps to examine.
 
-Consider evaluating the operator at some [timestamp](#25-timestamp) `t = (e, i)`, where `e` denotes the epoch, and `i` denotes the iteration.
+Consider evaluating the operator at some [timestamp](#25-time) `t = (e, i)`, where `e` denotes the epoch, and `i` denotes the iteration.
 
 Then there are two possible classes of elements which may be returned:
 1) Elements in the current input ZSet

--- a/dialog/pomo_db/pomo_flow.md
+++ b/dialog/pomo_db/pomo_flow.md
@@ -211,7 +211,7 @@ This operator takes an [Indexed ZSet](#22-indexed-zset) as input, and applies an
 
 (TODO: maybe it should use the circuit's current timestamp. I need to do some experimentation with timestamps because I think I can simplify the model slightly)
 
-Implementations MAY support user defined aggregates, but MUST support the aggregate functions described in the [specification for the query language](pomo_logic.md#aggregation).
+Implementations MAY support user defined aggregates, but MUST support the aggregate functions described in the [specification for the query language](pomo_logic.md#253-aggregation).
 
 If additional aggregates are supported, they MUST be pure functions, and implementations are RECOMMENDED to enforce this constraint.
 

--- a/dialog/pomo_db/pomo_flow.md
+++ b/dialog/pomo_db/pomo_flow.md
@@ -15,11 +15,9 @@ This document describes PomoFlow, a dataflow runtime for PomoDB. This design is 
 
 # 1. Introduction
 
-Most Datalog runtimes implement a variant of semi-naive evaluation, where queries are run over the course of multiple iterations, with each iteration refining the result toward a fixed point. Such designs can efficiently compute views over a fixed EDB, but are insufficient for incrementalizing evaluation over an EDB that changes over time.
+Most relational query runtimes implement a variant of semi-naive evaluation, where queries are run over the course of multiple iterations, with each iteration refining the result toward a fixed point. Such designs can efficiently compute views over a fixed database, but are insufficient for incrementalizing evaluation over a database that changes over time.
 
 This document describes an alternative runtime, built on dataflow, which represents programs as circuits whose vertices and edges correspond to computations over streams of data. These circuits can be incrementalized to instead operate over deltas, with the results being combined back into a materialized view.
-
-Since the stream computations correspond to the relational algebra, compiling to these circuits from PomoRA is simple, and is also described in this document.
 
 The design is based on ideas from Differential Dataflow, and is heavily inspired by the Database Stream Processor Framework (DBSP). Links to both can be found in the [research appendices](../RESEARCH.md).
 

--- a/dialog/pomo_db/pomo_flow.md
+++ b/dialog/pomo_db/pomo_flow.md
@@ -21,7 +21,7 @@ This document describes an alternative runtime, built on dataflow, which represe
 
 Since the stream computations correspond to the relational algebra, compiling to these circuits from PomoRA is simple, and is also described in this document.
 
-The design is based on ideas from Differential Dataflow, and is heavily inspired by the Database Stream Processor Framework (DBSP). Links to both can be found in the [research appendices](./RESEARCH.md).
+The design is based on ideas from Differential Dataflow, and is heavily inspired by the Database Stream Processor Framework (DBSP). Links to both can be found in the [research appendices](../RESEARCH.md).
 
 # 2. Concepts
 

--- a/dialog/pomo_db/pomo_logic.md
+++ b/dialog/pomo_db/pomo_logic.md
@@ -100,7 +100,7 @@ All rules discussed so far are examples of deductive rules. Similarly inductive 
 zeroPoint(x: X, y: Y)@next :− zeroPoint(x: X, y: Y).
 ```
 
-This causes the rule to delay derived tuples until the next timestep. For more information, see [section 1.3.2](#131-time).
+This causes the rule to delay derived tuples until the next timestep. For more information, see [section 1.2.2](#121-time).
 
 ### Predicates
 
@@ -117,24 +117,13 @@ popularProfile(id: X) :−
 
 Here, `c` is bound to the count of `follower` tuples whose `follows` attribute matches `X`. The result is then constrained to only those variable bindings whose associated counts are greater than 1000.
 
-Detailed descriptions of built-in predicates is provided in [section 1.3.5](#135-predicates).
+Detailed descriptions of built-in predicates is provided in [section 1.2.5](#125-predicates).
 
-## 1.2 Types
-
-PomoLogic is designed to be run within WebAssembly, and so its types and their encodings are informed by the format. See the [WebAssembly specification](https://webassembly.github.io/spec/core/appendix/index-types.html) for more information.
-
-Note, however, that only some types are supported as PomoLogic primitives. These are:
-
-- [Numbers](https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype)
-- [Opaque Reference Types](https://webassembly.github.io/spec/core/syntax/types.html#reference-types)
-
-As WebAssembly does not define common types like booleans or strings, these are handled using opaque reference types, and more information is available in the [serialization](./serialization.md) specification.
-
-## 1.3 Semantics
+## 1.2 Semantics
 
 PomoLogic follows a least fixed point semantics for Datalog, with stratified negation and aggregation, and extensions for reifying time and content IDs.
 
-## 1.3.1 Time
+## 1.2.1 Time
 
 Unlike many variants of Datalog, PomoLogic operates over a changing database, and the query engine internally models the progression of time as the database changes. Importantly, this notion of time forms a logical clock which holds no meaning to any other instances of PomoLogic.
 
@@ -164,7 +153,7 @@ This rule has three heads which together relate the current state of the checkbo
 
 Note that while this rule depends negatively on itself, it's able to do so safely because the timestamp of the head is larger than the timestamps of the atoms in the body, stratifying the program with respect to time.
 
-## 1.3.2 Content Addressing
+## 1.2.2 Content Addressing
 
 As PomoLogic is intended for use in distributed and decentralized deployments, it is important ensure the use of collision resistant identifiers when referring to tuples. For this purpose, a content addressing scheme is leveraged, wherein facts are associated with a content ID (CID) computed from their structure. The details behind this computation are available in [serialization](./serialization.md).
 
@@ -194,7 +183,7 @@ Since content addressing schemes are backed by cryptographically secure hash fun
 
 These properties are further leveraged in the design and use of byzantine-fault tolerant CRDTs, as described in [CRDTs](./CRDTs.md).
 
-## 1.3.3 Stratification
+## 1.2.3 Stratification
 
 PomoLogic supports recursion, negation, and aggregation, and in order to do so safely, it makes use of stratification. Stratification partitions a program's rules into a sequence of strata, based on their dependencies, such that all rules within a stratum depend on each other. These strata are then ordered such that no stratum appears before a stratum containing rules it depends on.
 
@@ -212,17 +201,17 @@ A program may have multiple valid stratifications, if one exists, but the choice
    2) Contract each strongly connected component in `G` to a single vertex, and add it to `C(G)`
    3) For any two distinct strongly connected components in `G`, `c1` and `c2`, if there exists an edge from a vertex in `c1` to a vertex in `c2`, then add a directed edge between the corresponding vertices for `c1` and `c2` in `C(G)`
 3) Perform a topological sort on `C(G)`: the resulting ordering gives the stratification of `P`, with each vertex in `C(G)`, `c`, corresponding to a stratum containing the rules in `P` whose head belongs to the strongly connected component of `G` for which `c` is associated
-4) Append a new stratum to the end, containing all inductive rules. This last stratum corresponds to the modular stratification over time discussed in [section 1.3.1](#131-time), and these rules MAY be implemented using [sinks](#136-sinks)
+4) Append a new stratum to the end, containing all inductive rules. This last stratum corresponds to the modular stratification over time discussed in [section 1.2.1](#121-time), and these rules MAY be implemented using [sinks](#126-sinks)
 
 Such a stratification is only valid if for every strongly connected component in `G`, no edge within that component is labelled with negative polarity. Intuitively, this prevents the use of negation or aggregation through recursive application of rules. Such programs are considered cannot be stratified, and therefore cannot be represented using PomoLogic.
 
-## 1.3.4 Evaluation
+## 1.2.4 Evaluation
 
-Evaluation of PomoLogic proceeds in [timesteps](#131-time), called epochs, which each compute a least fixed point over a batch of changes to the EDB. At each epoch, the program is evaluated in [stratum order](#133-stratification), by evaluating all rules within each stratum to a fixed point before evaluating the next stratum. A fixed point occurs when further applications of a rule against the current EDB and IDB do not result in the derivation of new tuples.
+Evaluation of PomoLogic proceeds in [timesteps](#121-time), called epochs, which each compute a least fixed point over a batch of changes to the EDB. At each epoch, the program is evaluated in [stratum order](#123-stratification), by evaluating all rules within each stratum to a fixed point before evaluating the next stratum. A fixed point occurs when further applications of a rule against the current EDB and IDB do not result in the derivation of new tuples.
 
-Each epoch is denoted by the timestamp succeeding the last, and begins by evaluating the program's [sources](#135-sources). These act as ingress points for the program, and introduce tuples from the outside world, such as by loading them from a local persistence layer, or by querying them from a remote data source such as IPFS.
+Each epoch is denoted by the timestamp succeeding the last, and begins by evaluating the program's [sources](#125-sources). These act as ingress points for the program, and introduce tuples from the outside world, such as by loading them from a local persistence layer, or by querying them from a remote data source such as IPFS.
 
-Upon evaluating all strata to a fixed point, the program's [sinks](#136-sinks) are evaluated against the current EDB and IDB. These act as egress points for the program, and emit tuples to the outside world for further storage or processing.
+Upon evaluating all strata to a fixed point, the program's [sinks](#126-sinks) are evaluated against the current EDB and IDB. These act as egress points for the program, and emit tuples to the outside world for further storage or processing.
 
 When evaluating a stratum, rules MAY be evaluated in any order.
 
@@ -233,7 +222,7 @@ Similarly, when evaluating a rule, predicates MAY be reordered, subject to the f
 
 PomoLogic MAY be implemented over incremental computations, in which case each epoch is RECOMMENDED to operate over deltas of the EDB, wherever possible. A recommended runtime in terms of a [dataflow model](./pomo_flow.md) is provided.
 
-## 1.3.5 Predicates
+## 1.2.5 Predicates
 
 ### Selection
 
@@ -245,7 +234,7 @@ Selection ::=
 
 In both cases, the predicate selects tuples from the relation given by the atom, unifying their attributes against the atom's attributes: unbound variables will be bound to the corresponding value in the tuple, and bound variables will filter the selection to include only tuples with matching values.
 
-The second form additionally unifies the [CID](#132-content-addressing) of the selected tuple with the given variable. If this variable has already been bound, then the selection is filtered to only include the tuple with the bound CID.
+The second form additionally unifies the [CID](#122-content-addressing) of the selected tuple with the given variable. If this variable has already been bound, then the selection is filtered to only include the tuple with the bound CID.
 
 ### Negation
 
@@ -382,7 +371,7 @@ diagonal(x: 1, y: 2)
 diagonal(x: 2, y: 2)
 ```
 
-## 1.3.5 Sources
+## 1.2.5 Sources
 
 Sources introduce tuples from the outside world to a running PomoLogic program. They do so at the beginning of each epoch.
 
@@ -392,7 +381,7 @@ Sources MAY emit deltas of tuples, if the PomoLogic implementation is able to ta
 
 Implementations MAY also support user defined sources, such as to facilitate the integration of PomoLogic into external systems for persistence or communication.
 
-## 1.3.6 Sinks
+## 1.2.6 Sinks
 
 Sinks process derived tuples at the end of each epoch.
 

--- a/dialog/pomo_db/pomo_logic.md
+++ b/dialog/pomo_db/pomo_logic.md
@@ -15,27 +15,23 @@ PomoDB is query language agnostic, and implementations MAY define arbitrary quer
 
 # 1. Introduction
 
-TODO: Now that the query language is described in a few layers, some of these details should be pulled out of PomoLogic so they can be reused for non-recursive queries: PomoRA is probably the place for that.
-
 The semantics of PomoLogic match those of Datalog, extended to support queries over time against a dynamic and content-addressable database.
 
 By restricting the expressivity of the engine in this way, it's able to take advantage of the CALM Theorem to ensure the confluence of any programs written using the system.
 
 Datalog is a relational query language that operates on a database of tuples, named atoms, using programmer defined rules, in order to compute a view over that database.
 
-The following section serves as a brief introduction to Datalog, but a comprehensive description of the language and its various extensions is beyond the scope of this specification, and more complete treatments can be found in the [research appendices](./RESEARCH.md).
+The following section serves as a brief introduction to Datalog, but a comprehensive description of the language and its various extensions is beyond the scope of this specification, and more complete treatments can be found in the [research appendices](../RESEARCH.md).
 
 ## 1.1 Notation
 
-This section briefly describes a high-level notation for Datalog, as it relates to PomoLogic, for the purposes of discussing the semantics of the system. An example DSL is [also available](./datalog-dsl.md).
+This section briefly describes a high-level notation for Datalog, as it relates to PomoLogic, for the purposes of discussing the semantics of the system. An example DSL is [also available](datalog-dsl.md).
 
 TODO: Either make this file or put that info elsewhere.
 
 ### Terms
 
 A Datalog term is either a constant, or a variable. Variables begin with an uppercase character, and constants are written as literals.
-
-The allowed types are defined in [section 1.2](#types).
 
 ### Atoms
 
@@ -155,11 +151,7 @@ Note that while this rule depends negatively on itself, it's able to do so safel
 
 ## 1.2.2 Content Addressing
 
-As PomoLogic is intended for use in distributed and decentralized deployments, it is important ensure the use of collision resistant identifiers when referring to tuples. For this purpose, a content addressing scheme is leveraged, wherein facts are associated with a content ID (CID) computed from their structure. The details behind this computation are available in [serialization](./serialization.md).
-
-(Note: this may not actually be the right way of thinking about this, because in many cases, these CIDs are for tuples derived from the EVAC tuples in IPFS, rather than the EVAC tuples themselves. Instead we might also want to accumulate the provenance of variables across joins, and expose a predicate that queries over that provenance. This provenance tracking might even happen conditionally, based on whether it's needed by the program)
-
-This CID is accessed through the selection predicate, which can optionally unify a tuple's CID with a variable:
+The [CID](../README.md#23-content-addressing) for a tuple is accessed through the selection predicate, which can optionally unify a tuple's CID with a variable:
 
 ```datalog
 C := point(x: X, y: Y)
@@ -176,12 +168,6 @@ categoryCount(category: Category, count: Count) :-
 ```
 
 In this example, the CID of each tuple in the `category` relation acts as its primary key, and is suitable for use as a foreign key when joining against this relation for aggregation purposes.
-
-The choice of CIDs here, rather than more common choices, like auto incrementing IDs or UUIDs, reflects PomoLogic's goals in targeting distributed and decentralized environments, where coordination around the allocation of IDs can't be guaranteed, and where resilience against malicious and byzantine actors is required.
-
-Since content addressing schemes are backed by cryptographically secure hash functions, their use here prevents forgery of IDs by attackers, and guarantees that CID-based dependencies between tuples will be acyclic.
-
-These properties are further leveraged in the design and use of byzantine-fault tolerant CRDTs, as described in [CRDTs](./CRDTs.md).
 
 ## 1.2.3 Stratification
 
@@ -220,7 +206,7 @@ Similarly, when evaluating a rule, predicates MAY be reordered, subject to the f
 - Aggregation predicates MUST NOT be evaluated until any bindings they share with the rule's body are fully grounded
 - Constraint predicates MUST NOT be evaluated until both terms are grounded
 
-PomoLogic MAY be implemented over incremental computations, in which case each epoch is RECOMMENDED to operate over deltas of the EDB, wherever possible. A recommended runtime in terms of a [dataflow model](./pomo_flow.md) is provided.
+PomoLogic MAY be implemented over incremental computations, in which case each epoch is RECOMMENDED to operate over deltas of the EDB, wherever possible. A recommended runtime in terms of a [dataflow model](pomo_flow.md) is provided.
 
 ## 1.2.5 Predicates
 
@@ -314,7 +300,7 @@ totalStock(category: Category, total: Total) :-
   Total := sum Quantity : product(category: Category, quantity: Quantity).
 ```
 
-Implementations MUST support the aggregate functions defined by [PomoRA](pomo_ra.md#312-group-by), and MAY provide additional non-standard aggregates or allow user defined aggregate functions.
+Implementations MUST support the aggregate functions defined by [PomoRA](pomo_ra.md#212-group-by), and MAY provide additional non-standard aggregates or allow user defined aggregate functions.
 
 The arguments to an aggregate's atom form a lexical scope under the rule's body, and new bindings introduced in this scope MUST NOT be accessible to other predicates.
 

--- a/dialog/pomo_db/pomo_logic.md
+++ b/dialog/pomo_db/pomo_logic.md
@@ -187,7 +187,7 @@ A program may have multiple valid stratifications, if one exists, but the choice
    2) Contract each strongly connected component in `G` to a single vertex, and add it to `C(G)`
    3) For any two distinct strongly connected components in `G`, `c1` and `c2`, if there exists an edge from a vertex in `c1` to a vertex in `c2`, then add a directed edge between the corresponding vertices for `c1` and `c2` in `C(G)`
 3) Perform a topological sort on `C(G)`: the resulting ordering gives the stratification of `P`, with each vertex in `C(G)`, `c`, corresponding to a stratum containing the rules in `P` whose head belongs to the strongly connected component of `G` for which `c` is associated
-4) Append a new stratum to the end, containing all inductive rules. This last stratum corresponds to a [modular stratification over time](#21-time), and these rules MAY be implemented using [sinks](#27-sinks)
+4) Append a new stratum to the end, containing all inductive rules. This last stratum corresponds to a [modular stratification over time](#21-time), and these rules MAY be implemented using [sinks](../README.md#27-sinks)
 
 Such a stratification is only valid if for every strongly connected component in `G`, no edge within that component is labelled with negative polarity. Intuitively, this prevents the use of negation or aggregation through recursive application of rules. Such programs are considered cannot be stratified, and therefore cannot be represented using PomoLogic.
 
@@ -195,9 +195,9 @@ Such a stratification is only valid if for every strongly connected component in
 
 Evaluation of PomoLogic proceeds in [timesteps](#21-time), called epochs, which each compute a least fixed point over a batch of changes to the EDB. At each epoch, the program is evaluated in [stratum order](#23-stratification), by evaluating all rules within each stratum to a fixed point before evaluating the next stratum. A fixed point occurs when further applications of a rule against the current EDB and IDB do not result in the derivation of new tuples.
 
-Each epoch is denoted by the timestamp succeeding the last, and begins by evaluating the program's [sources](#26-sources). These act as ingress points for the program, and introduce tuples from the outside world, such as by loading them from a local persistence layer, or by querying them from a remote data source such as IPFS.
+Each epoch is denoted by the timestamp succeeding the last, and begins by evaluating the program's [sources](../README.md#26-sources). These act as ingress points for the program, and introduce tuples from the outside world, such as by loading them from a local persistence layer, or by querying them from a remote data source such as IPFS.
 
-Upon evaluating all strata to a fixed point, the program's [sinks](#27-sinks) are evaluated against the current EDB and IDB. These act as egress points for the program, and emit tuples to the outside world for further storage or processing.
+Upon evaluating all strata to a fixed point, the program's [sinks](../README.md#27-sinks) are evaluated against the current EDB and IDB. These act as egress points for the program, and emit tuples to the outside world for further storage or processing.
 
 When evaluating a stratum, rules MAY be evaluated in any order.
 
@@ -356,24 +356,6 @@ diagonal(x: 1, y: 1)
 diagonal(x: 1, y: 2)
 diagonal(x: 2, y: 2)
 ```
-
-## 2.6 Sources
-
-Sources introduce tuples from the outside world to a running PomoLogic program. They do so at the beginning of each epoch.
-
-Implementations MAY define their own sources, but sources SHOULD be non-blocking, and are RECOMMENDED to perform any blocking or IO-intensive operations asynchronously.
-
-Sources MAY emit deltas of tuples, if the PomoLogic implementation is able to take advantage of incremental computation.
-
-Implementations MAY also support user defined sources, such as to facilitate the integration of PomoLogic into external systems for persistence or communication.
-
-## 2.7 Sinks
-
-Sinks process derived tuples at the end of each epoch.
-
-Implementations MAY define their own sinks, but sinks SHOULD be non-blocking, and are RECOMMENDED to perform any blocking or IO-intensive operations asynchronously.
-
-Implementations MAY also support user defined sinks, such as to facilitate the integration of PomoLogic into external systems for persistence or communication.
 
 # 3. Compilation to PomoRA
 

--- a/dialog/pomo_db/pomo_logic.md
+++ b/dialog/pomo_db/pomo_logic.md
@@ -189,7 +189,7 @@ A program may have multiple valid stratifications, if one exists, but the choice
    2) Contract each strongly connected component in `G` to a single vertex, and add it to `C(G)`
    3) For any two distinct strongly connected components in `G`, `c1` and `c2`, if there exists an edge from a vertex in `c1` to a vertex in `c2`, then add a directed edge between the corresponding vertices for `c1` and `c2` in `C(G)`
 3) Perform a topological sort on `C(G)`: the resulting ordering gives the stratification of `P`, with each vertex in `C(G)`, `c`, corresponding to a stratum containing the rules in `P` whose head belongs to the strongly connected component of `G` for which `c` is associated
-4) Append a new stratum to the end, containing all inductive rules. This last stratum corresponds to a [modular stratification over time](#21-time), and these rules MAY be implemented using [sinks](../README.md#28-sinks)
+4) Append a new stratum to the end, containing all inductive rules. This last stratum corresponds to a [modular stratification over time](#21-time)
 
 Such a stratification is only valid if for every strongly connected component in `G`, no edge within that component is labelled with negative polarity. Intuitively, this prevents the use of negation or aggregation through recursive application of rules. Such programs are considered cannot be stratified, and therefore cannot be represented using PomoLogic.
 

--- a/dialog/pomo_db/pomo_logic.md
+++ b/dialog/pomo_db/pomo_logic.md
@@ -191,7 +191,7 @@ Such a stratification is only valid if for every strongly connected component in
 
 ## 2.4 Evaluation
 
-Evaluation of PomoLogic extends PomoDB's [evaluation semantics](../README.md#27-evaluation) with some additional invariants.
+Evaluation of PomoLogic extends PomoDB's [evaluation semantics](../README.md#27-evaluation) with some additional guarantees.
 
 While the evaluation order for PomoLogic queries is generally unspecified, each epoch MUST be evaluated in [stratum order](#23-stratification), by evaluating all rules within each stratum to a fixed point before evaluating the next stratum. A fixed point occurs when further applications of a rule against the current EDB and IDB do not result in the derivation of new tuples.
 

--- a/dialog/pomo_db/pomo_logic.md
+++ b/dialog/pomo_db/pomo_logic.md
@@ -119,11 +119,7 @@ PomoLogic follows a least fixed point semantics for Datalog, with stratified neg
 
 ## 2.1 Time
 
-TODO: split some of this into the top-level spec to share between runtimes
-
-Unlike many variants of Datalog, PomoLogic operates over a changing database, and the query engine internally models the progression of time as the database changes. Importantly, this notion of time forms a logical clock which holds no meaning to any other instances of PomoLogic.
-
-The database state is then modeled as a function of time and the program under evaluation, but this computation is intentionally left unspecified, and implementations are free to make their own choices according to their performance constraints and desired features, subject to the following semantics.
+PomoLogic imposes additional constraints over PomoDB's concept of [time](../README.md#23-time).
 
 First, let `P` be some PomoLogic program, let `next(t)` denote the smallest timestamp `t'`, such that `t < t'`, and let `IDB(t, p)` denote the IDB at time `t`.
 
@@ -195,7 +191,7 @@ Such a stratification is only valid if for every strongly connected component in
 
 ## 2.4 Evaluation
 
-Evaluation of PomoLogic extends PomoDB's [evaluation semantics](../README.md#26-query-evaluation) with some additional invariants.
+Evaluation of PomoLogic extends PomoDB's [evaluation semantics](../README.md#27-evaluation) with some additional invariants.
 
 While the evaluation order for PomoLogic queries is generally unspecified, each epoch MUST be evaluated in [stratum order](#23-stratification), by evaluating all rules within each stratum to a fixed point before evaluating the next stratum. A fixed point occurs when further applications of a rule against the current EDB and IDB do not result in the derivation of new tuples.
 

--- a/dialog/pomo_db/pomo_ra.md
+++ b/dialog/pomo_db/pomo_ra.md
@@ -72,7 +72,7 @@ TODO: I'm not super clear on whether it's worth separating out the syntax for th
 
 # 2. Semantics
 
-PomoRA extends the relational alegbra to support recursive queries by leveraging an inflationary semantics over a loop construct.
+PomoRA extends the relational algebra to support recursive queries by leveraging an inflationary semantics over a loop construct.
 
 A program is evaluated over a database, which can be modeled as a map from [relation](../README.md#22-relation) identifiers, to relations.
 

--- a/dialog/pomo_db/pomo_ra.md
+++ b/dialog/pomo_db/pomo_ra.md
@@ -21,23 +21,7 @@ In the context of PomoDB, the relational algebra serves two purposes:
 1) Providing a small core language for further compilation to a runtime with support for recursive query processing
 2) Serving as a common intermediate representation for both queries written using familiar SQL-inspired DSLs, and for those written using richer, higher-level languages, like [PomoLogic](pomo_logic.md).
 
-# 2. Concepts
-
-## 2.1 Relation
-
-A relation is a set of tuples, where each component of the tuple is called an attribute, and can be referenced by an attribute name.
-
-A n-ary relation contains n-tuples, which can each be written:
-
-```
-(a1: v1, a2: v2, ..., an: vn)
-```
-
-Where `a1, a2, ..., an` give the names of each attribute, and `v1, v2, ..., vn` their values.
-
-Each tuple within a relation also has a content identifier (CID), as described in the specification for [PomoLogic](pomo_logic.md#132-content-addressing). This CID can be accessed through a special control attribute that this document will denote as `$CID`: however implementations are RECOMMENDED to use their type system to differentiate between such attributes.
-
-# 3. Operations
+# 2. Operations
 
 An operator specifies an operation against a stream, and is represented by a node. Linear operators are unary operators which can be computed using only the deltas at the current timestamp, and can be compiled to efficient incremental operations. Similarly, bilinear operations are binary operators which are linear with respect to each argument.
 
@@ -45,20 +29,20 @@ All operators take some number of relations as input, transforming them into an 
 
 | Name                                       | Linearity  | Arity |
 | ------------------------------------------ | ---------- | ----- |
-| [Projection](#31-projection)               | Linear     | 1     |
-| [Rename](#32-rename)                       | Linear     | 1     |
-| [Selection](#33-selection)                 | Linear     | 1     |
-| [Union](#34-union)                         | Linear     | N-ary |
-| [Difference](#35-difference)               | Non-Linear | 1     |
-| [Cartesian Product](#36-cartesian-product) | Bilinear   | 2     |
-| [Natural Join](#37-natural-join)           | Bilinear   | 2     |
-| [Theta Join](#38-theta-join)               | Bilinear   | 2     |
-| [Equijoin](#39-equijoin)                   | Bilinear   | 2     |
-| [Semijoin](#310-semijoin)                  | Bilinear   | 2     |
-| [Antijoin](#311-antijoin)                  | Bilinear   | 2     |
-| [Group By](#312-group-by)                  | Varies     | 1     |
+| [Projection](#21-projection)               | Linear     | 1     |
+| [Rename](#22-rename)                       | Linear     | 1     |
+| [Selection](#23-selection)                 | Linear     | 1     |
+| [Union](#24-union)                         | Linear     | N-ary |
+| [Difference](#25-difference)               | Non-Linear | 1     |
+| [Cartesian Product](#26-cartesian-product) | Bilinear   | 2     |
+| [Natural Join](#27-natural-join)           | Bilinear   | 2     |
+| [Theta Join](#28-theta-join)               | Bilinear   | 2     |
+| [Equijoin](#29-equijoin)                   | Bilinear   | 2     |
+| [Semijoin](#210-semijoin)                  | Bilinear   | 2     |
+| [Antijoin](#211-antijoin)                  | Bilinear   | 2     |
+| [Group By](#212-group-by)                  | Varies     | 1     |
 
-## 3.1 Projection
+## 2.1 Projection
 
 A projection is a unary operation which is parameterized over a set of attribute names, and restricts the tuples in its input relation to the attributes given by these names.
 
@@ -78,7 +62,7 @@ projection([:id, :name], [
 ]
 ```
 
-## 3.2 Rename
+## 2.2 Rename
 
 A rename is a unary operation which is parameterized over a pair of attribute names, `(from, to)`, whose input relation contains an attribute named `from`, but does not contain an attribute named `to`. It returns a relation whose tuples are identical to those in the input, except the attribute given by `from` is renamed to `to`.
 
@@ -98,9 +82,9 @@ rename([foo: :bar], [
 ]
 ```
 
-## 3.3 Selection
+## 2.3 Selection
 
-A selection is a unary operation which is parameterized over a [propositional formula](#4-propositional-formula), and that returns the tuples in its input relation for which this formula holds.
+A selection is a unary operation which is parameterized over a [propositional formula](#3-propositional-formula), and that returns the tuples in its input relation for which this formula holds.
 
 For example:
 
@@ -119,7 +103,7 @@ selection(born < 1960, [
 ]
 ```
 
-## 3.4 Union
+## 2.4 Union
 
 A union is an n-ary operation which performs a set union over its input relations. All of the input relations must be union-compatible, by sharing the same set of attribute names.
 
@@ -171,7 +155,7 @@ union(rgb, cmy, roygbiv) <=> union(rgb, union(cmy, roygbiv))
                          <=> ...
 ```
 
-## 3.5 Difference
+## 2.5 Difference
 
 Difference is a binary operation which performs a set difference over its input relations. 
 
@@ -205,7 +189,7 @@ difference(roygbiv, rgb) => [
 ]
 ```
 
-## 3.6 Cartesian Product
+## 2.6 Cartesian Product
 
 A Cartesian product is a binary operation which computes all possible pairs between two input relations. The relations MUST have disjoint attributes, and the tuples in the resulting set are flattened.
 
@@ -247,7 +231,7 @@ cartesian_product(ranks, suits) => [
 
 ```
 
-## 3.7 Natural Join
+## 2.7 Natural Join
 
 A natural join is a binary operator which computes the set of all combinations of the tuples in its input relations, such that the values of any attributes common to both relations are equal.
 
@@ -275,11 +259,11 @@ natural_join(languages, web_frameworks) => [
 ]
 ```
 
-## 3.8 Theta Join
+## 2.8 Theta Join
 
-A theta join is a binary operator which is parameterized over a [propositional formula](#4-propositional-formula), and that computes the set of all combinations of tuples in its input relations which satisfy that formula. The relations MUST have disjoint attributes, and the tuples in the resulting set are flattened.
+A theta join is a binary operator which is parameterized over a [propositional formula](#3-propositional-formula), and that computes the set of all combinations of tuples in its input relations which satisfy that formula. The relations MUST have disjoint attributes, and the tuples in the resulting set are flattened.
 
-This operation is equivalent to composing a [selection](#33-selection) with a [Cartesian product](#36-cartesian-product), however implementations are RECOMMENDED to implement theta joins as a specialization of these operations, for performance reasons.
+This operation is equivalent to composing a [selection](#23-selection) with a [Cartesian product](#26-cartesian-product), however implementations are RECOMMENDED to implement theta joins as a specialization of these operations, for performance reasons.
 
 For example:
 
@@ -304,11 +288,11 @@ theta_join(budget_category_id = product_category_id and cost < budget, products)
 ]
 ```
 
-## 3.9 Equijoin
+## 2.9 Equijoin
 
-An equijoin is a binary operator which is parameterized over a [propositional formula](#4-propositional-formula), where the [propositional formula](#4-propositional-formula) only makes use of equality. It computes the set of all combinations of tuples in its input relations for which the given attribute names are equal. The relations MUST have disjoint attributes, and the tuples in the resulting set are flattened.
+An equijoin is a binary operator which is parameterized over a [propositional formula](#3-propositional-formula), where the [propositional formula](#3-propositional-formula) only makes use of equality. It computes the set of all combinations of tuples in its input relations for which the given attribute names are equal. The relations MUST have disjoint attributes, and the tuples in the resulting set are flattened.
 
-This operation MAY be implemented using [theta join](#38-theta-join), however it is RECOMMENDED that equijoins are specialized, for performance reasons.
+This operation MAY be implemented using [theta join](#28-theta-join), however it is RECOMMENDED that equijoins are specialized, for performance reasons.
 
 ```
 categories = [
@@ -331,11 +315,11 @@ equijoin(category_id = product_category_id, products) => [
 ]
 ```
 
-## 3.10 Semijoin
+## 2.10 Semijoin
 
 A semijoin is a binary operator which returns all tuples in its first input relation such that there is a tuple in its second relation for which the common attributes of both tuples are equal.
 
-This operation is equivalent to composing a [projection](#31-projection) again the first relation's attributes with a [natural join](#37-natural-join), however implementations are RECOMMENDED to implement semijoins as a specialization of these operations, for performance reasons.
+This operation is equivalent to composing a [projection](#21-projection) again the first relation's attributes with a [natural join](#27-natural-join), however implementations are RECOMMENDED to implement semijoins as a specialization of these operations, for performance reasons.
 
 For example:
 
@@ -357,13 +341,13 @@ semijoin(users, admins) [
 ]
 ```
 
-## 3.11 Antijoin
+## 2.11 Antijoin
 
 An antijoin is a binary operator which returns all tuples in its first input relation such that there is no tuple in its second relation for which the common attributes of both tuples are equal.
 
-This operation is equivalent to taking the [difference](#35-difference) of the first relation and the [semijoin](#310-semijoin) of both, however implementations are RECOMMENDED to implement antijoins as a specialization of these operations, for performance reasons.
+This operation is equivalent to taking the [difference](#25-difference) of the first relation and the [semijoin](#210-semijoin) of both, however implementations are RECOMMENDED to implement antijoins as a specialization of these operations, for performance reasons.
 
-## 3.12 Group By
+## 2.12 Group By
 
 Group by is the mechanism by which aggregation is performed. Group by is performed over a relation with respect to a set of grouping attributes, and an aggregate function. The operation returns the set of tuples computed by first grouping the input relation, and then applying the aggregate function to each group.
 
@@ -398,9 +382,9 @@ group_by(
 ]
 ```
 
-# 4. Propositional Formula
+# 3. Propositional Formula
 
-Selection criterion for operations like [selection](#33-selection) and [theta joins](#38-theta-join) are specified in terms of a small subset of propositional logic.
+Selection criterion for operations like [selection](#23-selection) and [theta joins](#28-theta-join) are specified in terms of a small subset of propositional logic.
 
 A propositional formula is canonically represented in disjunctive normal form, as a disjunction of conjunctives:
 
@@ -429,13 +413,13 @@ select(formula, users) => [
 ]
 ```
 
-# 5. Compilation from PomoLogic
+# 4. Compilation from PomoLogic
 
 TODO: I realize this is very verbose and that it can be simplified and broken up. I'll worry about that after the first pass through describing things :)
 
 TODO: I need to move some details from PomoLogic to here, so that PomoRA can reuse ideas like provenance, CIDs, time, and stratification
 
-The translation from [PomoLogic](pomo_logic.md) to a relational algebra query plan is straightforward, and can be performed by first compiling each rule in isolation, and then taking the [union](#34-union) of the query plans for any rules with matching head atoms.
+The translation from [PomoLogic](pomo_logic.md) to a relational algebra query plan is straightforward, and can be performed by first compiling each rule in isolation, and then taking the [union](#24-union) of the query plans for any rules with matching head atoms.
 
 A rule is compiled by constructing a query plan from the terms within the rule's body, with respect to the rule's head. Such query plans are not unique, and implementations MAY define their own approach to query planning, but the semantics of the generated query plan MUST match the query plan generated using the following approach.
 
@@ -452,45 +436,45 @@ Now, for each predicate in `selections`, we have two cases:
 - `atom(a0: v0, ..., an: vn)`
 - `Var := atom(a0: v0, ..., an: vn)`
 
-In both cases, start by generating a [projection](#31-projection) operation against `atom`, for the attributes `a0, ..., an`. In the second case, additionally project against the control column `$CID`. Denote this operation by `source`.
+In both cases, start by generating a [projection](#21-projection) operation against `atom`, for the attributes `a0, ..., an`. In the second case, additionally project against the control column `$CID`. Denote this operation by `source`.
 
-Then, for all attributes `a`, with value `v`, and `v` being a constant, generate a [propositional formula](#4-propositional-formula) made up of the conjunction of all such attributes being compared for equality against their associated value. If this formula contains any terms, then generate a [selection](#33-selection) against `source`, that filters by this formula, and denote the resulting relation by `source`.
+Then, for all attributes `a`, with value `v`, and `v` being a constant, generate a [propositional formula](#3-propositional-formula) made up of the conjunction of all such attributes being compared for equality against their associated value. If this formula contains any terms, then generate a [selection](#23-selection) against `source`, that filters by this formula, and denote the resulting relation by `source`.
 
-Now, for all attributes `a`, with value `v`, and `v` being a variable, if this set is non-empty, then generate a [rename](#32-rename) operation against `source`, that renames every attribute `a` to `name(v)`. If the CID of the relation is being bound to a variable, `var`, additionally rename `$CID` to `name(var)`. Store the resulting relation in a set denoted by `sources`.
+Now, for all attributes `a`, with value `v`, and `v` being a variable, if this set is non-empty, then generate a [rename](#22-rename) operation against `source`, that renames every attribute `a` to `name(v)`. If the CID of the relation is being bound to a variable, `var`, additionally rename `$CID` to `name(var)`. Store the resulting relation in a set denoted by `sources`.
 
 Next, fold over the relations in `sources`, using the first relation as the initial accumulator. For each pair of relations considered, `left` and `right`, there are three possibilities:
 1) `left` and `right` share no common attributes
-   - Return the [cartesian product](#36-cartesian-product) of `left` and `right` as the new accumulator
+   - Return the [cartesian product](#26-cartesian-product) of `left` and `right` as the new accumulator
 2) The attributes of `right` are fully contained in the attributes of `left` (or the reverse is true)
-    - Return the [semijoin](#310-semijoin) of `left` and `right` as the new accumulator
+    - Return the [semijoin](#210-semijoin) of `left` and `right` as the new accumulator
 3) `left` and `right` share some common attributes
-    - Return the [natural join](#37-natural-join) of `left` and `right` as the new accumulator
+    - Return the [natural join](#27-natural-join) of `left` and `right` as the new accumulator
 
 At the end of this process, the fold will have returned a relation corresponding to the joining of all positive terms in the rule's body. Denote that relation `rule_body`.
 
-Then, compile `constraints` to a single [propositional formula](#4-propositional-formula), `prop_constraints`, made up of the conjunction of all constraints, such that all variables, `var`, are replaced with `name(var)`.
+Then, compile `constraints` to a single [propositional formula](#3-propositional-formula), `prop_constraints`, made up of the conjunction of all constraints, such that all variables, `var`, are replaced with `name(var)`.
 
 For example:
  - `[x <= 5] => name(x) <= 5`
  - `[x <= y, y = 5] => name(x) <= name(y) AND name(y) = 5`
 
- If `prop_constraints` is non-empty, then generate a [selection](#33-selection) against `rule_body` using `prop_constraints` as its formula. Denote the resulting relation as the new `rule_body`.
+ If `prop_constraints` is non-empty, then generate a [selection](#23-selection) against `rule_body` using `prop_constraints` as its formula. Denote the resulting relation as the new `rule_body`.
 
- Now, for each predicate in `negations`, `!atom(a0: v0, ..., an: vn)`, start by generating a [projection](#31-projection) operation against `atom`, for the attributes `a0, ..., an`. Denote the resulting relation as `negated_relation`.
+ Now, for each predicate in `negations`, `!atom(a0: v0, ..., an: vn)`, start by generating a [projection](#21-projection) operation against `atom`, for the attributes `a0, ..., an`. Denote the resulting relation as `negated_relation`.
 
- Then, for all attributes `a`, with value `v`, and `v` being a constant, generate a [propositional formula](#4-propositional-formula) made up of the conjunction of all such attributes being compared for equality against their associated value. If this formula contains any terms, then generate a [selection](#33-selection) against `negation`, that filters by this formula, and denote the resulting relation by `negated_relation`.
+ Then, for all attributes `a`, with value `v`, and `v` being a constant, generate a [propositional formula](#3-propositional-formula) made up of the conjunction of all such attributes being compared for equality against their associated value. If this formula contains any terms, then generate a [selection](#23-selection) against `negation`, that filters by this formula, and denote the resulting relation by `negated_relation`.
 
- Now, for all attributes `a`, with value `v`, and `v` being a variable, if this set is non-empty, then generate a [rename](#32-rename) operation against `negated_relation`, that renames every attribute `a` to `name(v)`. Store the resulting relation in a set denoted by `negated_relations`.
+ Now, for all attributes `a`, with value `v`, and `v` being a variable, if this set is non-empty, then generate a [rename](#22-rename) operation against `negated_relation`, that renames every attribute `a` to `name(v)`. Store the resulting relation in a set denoted by `negated_relations`.
 
-Next, fold over the relations in `negated_relations`, using `rule_body` as the initial accumulator. For each pair of relations considered, `negated_relation` and `accumulator`, return an [antijoin](#311-antijoin) between `accumulator` and `negated_relation` as the new accumulator.
+Next, fold over the relations in `negated_relations`, using `rule_body` as the initial accumulator. For each pair of relations considered, `negated_relation` and `accumulator`, return an [antijoin](#211-antijoin) between `accumulator` and `negated_relation` as the new accumulator.
 
 At the end of this process, the fold will have returned a relation corresponding to the joining of all positive terms in the rule's body, the selection of any constraints, along with the negation of all negative terms in the rule's body. Denote that relation `rule_body`.
 
 TODO: aggregation
 
-Next, from the rule's head, `atom(a0: v0, ..., an: vn)`, collect each attribute, `a`, with value `v`, and `v` being a variable, and generate a [rename](#32-rename) operation against `rule_body`, that renames every attribute `name(v)` to `a`. The resulting relation will contain the output for the rule.
+Next, from the rule's head, `atom(a0: v0, ..., an: vn)`, collect each attribute, `a`, with value `v`, and `v` being a variable, and generate a [rename](#22-rename) operation against `rule_body`, that renames every attribute `name(v)` to `a`. The resulting relation will contain the output for the rule.
 
-Now, taking the [union](#34-union) of all rules which share a head relation will give the query plan for that relation.
+Now, taking the [union](#24-union) of all rules which share a head relation will give the query plan for that relation.
 
 Lastly, [stratify](pomo_logic.md#133-stratification) each of these relations and partition the query plans by the strata they belong to.
 


### PR DESCRIPTION
📙 [Preview](https://github.com/fission-codes/spec/tree/quinn/pomodb-reorg/dialog/README.md)

This is still a work in progress, and there's some duplicate info spread between both the specs for PomoRA and PomoFlow that I'm still consolidating together in a logical way.