### PR TITLE
Change HLS to HTTP Streaming

### DIFF
--- a/.custom-words.txt
+++ b/.custom-words.txt
@@ -33,7 +33,6 @@ Equijoin
 FPP
 Filecoin
 Golang
-HLS
 HTTPS
 Herbrand
 Holmgren

--- a/car-pool/README.md
+++ b/car-pool/README.md
@@ -29,7 +29,7 @@ We propose developing a transport agnostic CAR-based synchronization mechanism, 
 
 This proposal resolves multiple major, persistent challenges that numerous production IPFS operators have experienced. We believe the scope of this work to be an important stepping stone in the maturation of IPFS and Filecoin in production settings.
 
-We propose extending the existing efforts to move specifically CAR files over HTTP (e.g. Filecoin point-to-point CAR, Qri’s DSync), and enable other transports such as WSS, HLS, and WebRTC. We know of several other projects in the broader ecosystem that would like to make use of this protocol, from storage providers and CDNs to decentralized social media protocols.
+We propose extending the existing efforts to move specifically CAR files over HTTP (e.g. Filecoin point-to-point CAR, Qri’s DSync), and enable other transports such as [WSS](https://datatracker.ietf.org/doc/html/rfc6455), [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5), and [WebRTC](https://datatracker.ietf.org/doc/html/rfc8835). We know of several other projects in the broader ecosystem that would like to make use of this protocol, from storage providers and CDNs to decentralized social media protocols.
 
 IPLD (and content addressing broadly) has an incredible advantage over conventional RESTful transfers: IPLD can easily deduplicate data. We strongly desire to retain this property. At Fission, our in-house file system (WNFS) is immutable-by-default. Uploading many redundant gigabytes for a small change is not practical.
 
@@ -41,11 +41,11 @@ Further, due to the Want List behavior being session agnostic, we have observed 
 
 ### HTTPS & WSS Are Mature Transports
 
-Streaming CAR files know that there is an open connection over a reliable, mature transport: HTTP, Streaming HTTP, and persistent WSS. Being able to efficiently push and fetch IPLD in CAR files over HTTP in particular means gaining the ability to move data over a mature, absolutely ubiquitous transport on privileged ports.
+Streaming CAR files know that there is an open connection over a reliable, mature transport: HTTP, [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5), and persistent [WSS](https://datatracker.ietf.org/doc/html/rfc6455). Being able to efficiently push and fetch IPLD in CAR files over HTTP in particular means gaining the ability to move data over a mature, absolutely ubiquitous transport on privileged ports.
 
 Relying on HTTP also makes TLS available everywhere, improving the security and privacy of messages. Since the proposed protocol does not depend on the public DHT (see Scope section), this provides some improvement even with public providers. The lack of dependence on the public DHT is well suited to short-lived nodes, such as browsers, GitHub Actions, and battery-sensitive devices such as mobile phones.
 
-It is worth highlighting that HTTP is unable to support many P2P use cases, and many client devices are not directly dialable as data providers. Those use cases will need continued dependence on WebRTC and similar. These strategies can run entirely in parallel, and are in no way mutually exclusive. A node being undialable leads to some difficulty in the design of this system, but even under these conditions, CAR protocols can be constructed that perform better than the naive case.
+It is worth highlighting that HTTP is unable to support many P2P use cases, and many client devices are not directly dialable as data providers. Those use cases will need continued dependence on [WebRTC](https://datatracker.ietf.org/doc/html/rfc8835) and similar. These strategies can run entirely in parallel, and are in no way mutually exclusive. A node being undialable leads to some difficulty in the design of this system, but even under these conditions, CAR protocols can be constructed that perform better than the naive case.
 
 ### Deduplication
 

--- a/car-pool/car-mirror/SPEC.md
+++ b/car-pool/car-mirror/SPEC.md
@@ -85,7 +85,7 @@ Whether a peer can initiate contact with a particular node. For example, a web b
 
 ## 2.2.1 Streaming CAR
 
-A CAR file can be expressed as a streaming data structure, and transmitted over [HTTP Live Streaming](https://datatracker.ietf.org/doc/html/rfc8216), [WebSockets](https://www.rfc-editor.org/rfc/rfc6455.html) or similar.
+A CAR file can be expressed as a streaming data structure, and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5), [WebSockets](https://datatracker.ietf.org/doc/html/rfc6455) or similar.
 
 ## 2.3 Session
 
@@ -103,7 +103,7 @@ Each round of communication will have fewer stragglers. There is a degenerate ca
 
 # 3. Transport
 
-The protocol here is described in discrete rounds. When run over fully bidirectional transports such as WSS, portions of rounds may be updated live rather than waiting for an arbitrary "round" to complete. Unidirectional transports like HTTP proceed in clear, distinct rounds. Discrete rounds are given below both because many transports require this mode, and because it is easier to explain in structured steps, even if not a hard requirement.
+The protocol here is described in discrete rounds. When run over fully bidirectional transports such as [WSS](https://datatracker.ietf.org/doc/html/rfc6455), portions of rounds may be updated live rather than waiting for an arbitrary "round" to complete. Unidirectional transports like HTTP proceed in clear, distinct rounds. Discrete rounds are given below both because many transports require this mode, and because it is easier to explain in structured steps, even if not a hard requirement.
 
 ## 3.1 Phases
 

--- a/car-pool/car-mirror/http.md
+++ b/car-pool/car-mirror/http.md
@@ -26,7 +26,7 @@ Note the absence of a field for the requested URL. Since multiple CID roots MAY 
 
 #### 1.1.1 `stream` Parameter
 
-This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over HLS.
+This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5).
 
 ## 1.2 Requestor Payload
 
@@ -63,7 +63,7 @@ POST /api/v0/dag/push?stream={bool}&diff={ipns | dnslink | cid}
 
 ### 2.1.1 `stream` Parameter
 
-This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over HLS.
+This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5).
 
 ### 2.1.2 `diff` Parameter
 

--- a/car-pool/car-mirror/http.md
+++ b/car-pool/car-mirror/http.md
@@ -26,7 +26,7 @@ Note the absence of a field for the requested URL. Since multiple CID roots MAY 
 
 #### 1.1.1 `stream` Parameter
 
-This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5).
+This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5).  Both the Requestor and Provider MUST use [HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540).
 
 ## 1.2 Requestor Payload
 


### PR DESCRIPTION
- Change HTTP Live Streaming/HLS to "HTTP Streaming", and link to RFC for HTTP/2 Streams.
- Update other links for consistency