### PR TITLE
CAR Mirror — switch to IPLD Schema

### DIFF
--- a/car-pool/car-mirror/http.md
+++ b/car-pool/car-mirror/http.md
@@ -85,7 +85,7 @@ This field MUST NOT be interpreted as a CID root being sent.
 ## 2.2 Requestor Payload
 
 ```ipldsch
-type UploadRequest struct {
+type PushRequest struct {
   bk Integer -- Bloom filter hash count
   bb Bytes   -- Bloom filter Binary
   pl CARv1   -- Data payload
@@ -97,7 +97,7 @@ The data payload (`pl`) MUST be encoded as a [CARv1]. If the streaming flag was 
 ## 2.3 Provider Payload
 
 ```ipldsch
-type UploadResponse struct {
+type PushResponse struct {
   sr [Link]  -- Incomplete subgraph roots
   bk Integer -- Bloom filter hash count
   bb Bytes   -- Bloom filter Binary

--- a/car-pool/car-mirror/http.md
+++ b/car-pool/car-mirror/http.md
@@ -84,27 +84,25 @@ This field MUST NOT be interpreted as a CID root being sent.
 
 ## 2.2 Requestor Payload
 
-The requestor payload MUST be serialized as [CBOR].
+```ipldsch
+type UploadRequest struct {
+  bk Integer -- Bloom filter hash count
+  bb Bytes   -- Bloom filter Binary
+  pl CARv1   -- Data payload
+} representation tuple
+```
+
+The data payload (`pl`) MUST be encoded as a [CARv1]. If the streaming flag was set in the URL, then the CAR MUST be a [streaming CARv1].
+
+## 2.3 Provider Payload
 
 ```ipldsch
-type ReqPayload struct {
+type UploadResponse struct {
   sr [Link]  -- Incomplete subgraph roots
   bk Integer -- Bloom filter hash count
   bb Bytes   -- Bloom filter Binary
 }
 ```
-
-## 2.3 Provider Payload
-
-```ipldsch
-type ProvPayload struct {
-  bk Integer -- Bloom filter hash count
-  bb Bytes   -- Bloom filter Binary
-  pl CarFile -- Data payload
-} representation tuple
-```
-
-The data payload (`pl`) MUST be encoded as a [CARv1]. If the streaming flag was set in the URL, then the CAR MUST be a [streaming CARv1].
 
 ## 2.4 Provider Status Codes
 

--- a/car-pool/car-mirror/http.md
+++ b/car-pool/car-mirror/http.md
@@ -40,7 +40,7 @@ This field specifies if the Provider should use discrete or streaming. `stream` 
 The requestor payload MUST be serialized as [CBOR]. 
 
 ```ipldsch
-type PullPayload struct {
+type PullRequest struct {
   rs [Link]  -- Requested CID roots
   bk Integer -- Bloom filter hash count
   bb Bytes   -- Bloom filter Binary

--- a/car-pool/car-mirror/http.md
+++ b/car-pool/car-mirror/http.md
@@ -2,15 +2,22 @@
 
 ## Authors
 
-* [Brooklyn Zelenka](https://github.com/expede), [Fission](https://fission.codes)
+* [Brooklyn Zelenka], [Fission]
+
+## Dependencies
+
+- [CARv1]
+- [CBOR]
+- [HTTP/2]
+- [IPLD Schema]
+
+## Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119].
 
 # 0. Abstract
 
 CAR Mirror is transport agnostic, and MAY be implemented with a RESTful HTTP client/server. This specification describes the protocol for CAR Mirror over HTTP.
-
-## 0.1 Language
-
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
 # 1. Pull
 
@@ -26,11 +33,11 @@ Note the absence of a field for the requested URL. Since multiple CID roots MAY 
 
 #### 1.1.1 `stream` Parameter
 
-This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5). Both the Requestor and Provider MUST use [HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540).
+This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming]. Both the Requestor and Provider MUST use [HTTP/2].
 
 ## 1.2 Requestor Payload
 
-The requestor payload MUST be serialized as [CBOR](https://cbor.io/). 
+The requestor payload MUST be serialized as [CBOR]. 
 
 ```ipldsch
 type PullPayload struct {
@@ -42,11 +49,11 @@ type PullPayload struct {
 
 ## 1.3 Provider Payload
 
-The response MUST be given as a [CARv1](https://ipld.io/specs/transport/car/carv1/). If the streaming flag was set in the URL, then the CAR MUST be a [streaming CARv1](https://ipld.io/specs/transport/car/carv1/#performance).
+The response MUST be given as a [CARv1]. If the streaming flag was set in the URL, then the CAR MUST be a [streaming CARv1].
 
 ## 1.4 Status Codes
 
-Status codes are [as defined in RFC2616 §10](https://www.rfc-editor.org/rfc/rfc2616#section-10), with no additional special meaning. For example, the common cases of success and lack of further CID roots would be:
+Status codes are [as defined in RFC2616 §10][RFC2616 #10], with no additional special meaning. For example, the common cases of success and lack of further CID roots would be:
 
 * Success: `200`
 * Unable to find any new root CIDs: `404`
@@ -63,7 +70,7 @@ POST /api/v0/dag/push?stream={bool}&diff={ipns | dnslink | cid}
 
 ### 2.1.1 `stream` Parameter
 
-This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5).
+This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming].
 
 ### 2.1.2 `diff` Parameter
 
@@ -71,37 +78,51 @@ The `diff` field is OPTIONAL. It represents a related CID to the one being pushe
 
 While a mutable pointer (IPNS or DNSLink) MAY be resolved to a CID before the request is constructed, it is RECOMMENDED that the pointer be given when available. This strategy gives the Provider more flexibility for tracking the last value that they've seen for that pointer, and conveys more about the Requestor's intention.
 
-This field is primarily useful for the [narrowing step](#312-narrowing), and especially during a [cold call](#3131-cold-calls). Since the Requestor does not have knowledge of everything in the Provider's store, this field provides a hint for the Provider of what (finite) context to include as part of the Bloom in their response.
+This field is primarily useful for the narrowing step, and especially during a cold call. Since the Requestor does not have knowledge of everything in the Provider's store, this field provides a hint for the Provider of what (finite) context to include as part of the Bloom in their response.
 
 This field MUST NOT be interpreted as a CID root being sent.
 
 ## 2.2 Requestor Payload
 
+The requestor payload MUST be serialized as [CBOR].
+
 ```ipldsch
 type ReqPayload struct {
-  bk Integer -- Bloom filter hash count
-  bb Bytes   -- Bloom filter Binary
-  pl CarFile -- Data payload
-} representation tuple
-```
-
-The data payload MUST be given as a [CARv1](https://ipld.io/specs/transport/car/carv1/). If the streaming flag was set in the URL, then the CAR MUST be a [streaming CARv1](https://ipld.io/specs/transport/car/carv1/#performance).
-
-## 2.3 Provider Payload
-
-The requestor payload MUST be serialized as [CBOR](https://cbor.io/).
-
-```ipldsch
-type ProvPayload struct {
   sr [Link]  -- Incomplete subgraph roots
   bk Integer -- Bloom filter hash count
   bb Bytes   -- Bloom filter Binary
 }
 ```
 
+## 2.3 Provider Payload
+
+```ipldsch
+type ProvPayload struct {
+  bk Integer -- Bloom filter hash count
+  bb Bytes   -- Bloom filter Binary
+  pl CarFile -- Data payload
+} representation tuple
+```
+
+The data payload (`pl`) MUST be encoded as a [CARv1]. If the streaming flag was set in the URL, then the CAR MUST be a [streaming CARv1].
+
 ## 2.4 Provider Status Codes
 
-Status codes are [as defined in RFC2616 §10](https://www.rfc-editor.org/rfc/rfc2616#section-10), with no additional special meaning. For example, a few common cases would include:
+Status codes are [as defined in RFC2616 §10][RFC2616 #10], with no additional special meaning. For example, a few common cases would include:
 
 * Complete: `200`
 * Success: `202`
+
+<!-- External Links -->
+
+[Brooklyn Zelenka]: https://github.com/expede
+[CARv1]: https://ipld.io/specs/transport/car/carv1/
+[CBOR]: https://cbor.io/
+[CBOR]: https://cbor.io/
+[Fission]: https://fission.codes
+[HTTP Streaming]: https://datatracker.ietf.org/doc/html/rfc7540#section-5
+[HTTP/2]: https://datatracker.ietf.org/doc/html/rfc7540
+[IPLD Schema]: https://ipld.io/docs/schemas/
+[RFC2119]: https://datatracker.ietf.org/doc/html/rfc2119
+[RFC2616 #10]: https://www.rfc-editor.org/rfc/rfc2616#section-10
+[streaming CARv1]: https://ipld.io/specs/transport/car/carv1/#performance

--- a/car-pool/car-mirror/http.md
+++ b/car-pool/car-mirror/http.md
@@ -26,17 +26,17 @@ Note the absence of a field for the requested URL. Since multiple CID roots MAY 
 
 #### 1.1.1 `stream` Parameter
 
-This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5).  Both the Requestor and Provider MUST use [HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540).
+This field specifies if the Provider should use discrete or streaming. `stream` MUST default to `false`. If streaming is set to `true`, the response MUST be a streaming CAR file and transmitted over [HTTP Streaming](https://datatracker.ietf.org/doc/html/rfc7540#section-5). Both the Requestor and Provider MUST use [HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540).
 
 ## 1.2 Requestor Payload
 
-The requestor payload MUST be serialized as [CBOR](https://cbor.io/). This schema is given in [CDDL (RFC8601)](https://datatracker.ietf.org/doc/html/rfc8610).
+The requestor payload MUST be serialized as [CBOR](https://cbor.io/). 
 
-```cddl
-payload = {
-  rs: [* cid], ; Requested CID roots
-  bk: uint,    ; Bloom filter hash count
-  bb: bytes,   ; Bloom filter Binary
+```ipldsch
+type PullPayload struct {
+  rs [Link]  -- Requested CID roots
+  bk Integer -- Bloom filter hash count
+  bb Bytes   -- Bloom filter Binary
 }
 ```
 
@@ -77,25 +77,25 @@ This field MUST NOT be interpreted as a CID root being sent.
 
 ## 2.2 Requestor Payload
 
-```cddl
-payload = {
-  bk : uint,  ; Bloom filter hash count
-  bb : bytes, ; Bloom filter Binary
-  pl : car,   ; Data payload
-}
+```ipldsch
+type ReqPayload struct {
+  bk Integer -- Bloom filter hash count
+  bb Bytes   -- Bloom filter Binary
+  pl CarFile -- Data payload
+} representation tuple
 ```
 
 The data payload MUST be given as a [CARv1](https://ipld.io/specs/transport/car/carv1/). If the streaming flag was set in the URL, then the CAR MUST be a [streaming CARv1](https://ipld.io/specs/transport/car/carv1/#performance).
 
 ## 2.3 Provider Payload
 
-The requestor payload MUST be serialized as [CBOR](https://cbor.io/). This schema is given in [CDDL (RFC8601)](https://datatracker.ietf.org/doc/html/rfc8610).
+The requestor payload MUST be serialized as [CBOR](https://cbor.io/).
 
-```cddl
-payload = {
-  sr : [* cid], ; Incomplete subgraph roots
-  bk : uint,    ; Bloom filter hash count
-  bb : bytes,   ; Bloom filter Binary
+```ipldsch
+type ProvPayload struct {
+  sr [Link]  -- Incomplete subgraph roots
+  bk Integer -- Bloom filter hash count
+  bb Bytes   -- Bloom filter Binary
 }
 ```
 


### PR DESCRIPTION
[👀 Preview](https://github.com/fission-codes/spec/blob/fixup-car-mirror/car-pool/car-mirror/http.md)

Swithing from CDDL to IPLD Schema. I do remember why we didn't want to do this origianlly: IPLD canonicalizes map fields, and we wanted to control the order of the data layout.

_However_, there are ways of doing that in IPLD Schema. See comments inline.

It also seems appropriate to do this in IPLD given the IPFS-ecosystem audience.